### PR TITLE
adaptive time slicing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argovisHelpers"
-version = "0.0.9"
+version = "0.0.10-rc1"
 description = "Helper functions to consume and parse information from University of Colorado's Argovis API."
 readme = "README.md"
 authors = [{name = "Bill Mills" }]


### PR DESCRIPTION
Rethinks #12 to only salami-slice requests in time. Spacial slicing dumbly can end up making a lot of 404s that nonetheless consume API token resources, slowing things down unnecessarily for the user. Squeezing geographically large requests in time still keeps things manageable, but avoids geometry headaches.