### PR TITLE
fallback for version fishing

### DIFF
--- a/argovisHelpers/helpers.py
+++ b/argovisHelpers/helpers.py
@@ -3,6 +3,7 @@ from shapely.geometry import shape, box, Polygon
 from shapely.ops import orient
 import geopandas as gpd
 import pkg_resources
+from pkg_resources import DistributionNotFound
 
 def slice_timesteps(options, r):
     # given a qsr option dict and data route, return a list of reasonable time divisions
@@ -224,7 +225,11 @@ def argofetch(route, options={}, apikey='', apiroot='https://argovis-api.colorad
         if option in options:
             options[option] = str(options[option])
 
-    dl = requests.get(apiroot.rstrip('/') + '/' + route.lstrip('/'), params = options, headers={'x-argokey': apikey, 'x-avh-telemetry': pkg_resources.get_distribution('argovisHelpers').version})
+    try:
+        version = pkg_resources.get_distribution('argovisHelpers').version
+    except DistributionNotFound:
+        version = '-1'
+    dl = requests.get(apiroot.rstrip('/') + '/' + route.lstrip('/'), params = options, headers={'x-argokey': apikey, 'x-avh-telemetry': version})
     statuscode = dl.status_code
     if verbose:
         print(urllib.parse.unquote(dl.url))


### PR DESCRIPTION
tests incorrectly fail just because the test environment doesn't have a release version of this package installed in it (it tests HEAD).