### PR TITLE
big slice bugfix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,11 @@ jobs:
 
     services:
       database:
-        image: argovis/testdb:0.41
+        image: argovis/testdb:0.45
       redis:
         image: redis:7.0.2
       api:
-        image: argovis/api:2.24.3
+        image: argovis/api:2.30.0
         env:
           ARGONODE: core
 

--- a/argovisHelpers/helpers.py
+++ b/argovisHelpers/helpers.py
@@ -261,12 +261,12 @@ def query(route, options={}, apikey='', apiroot='https://argovis-api.colorado.ed
     # start by just trying the request, to determine if we need to slice it
     if not slice:
         try:
-            q = argofetch(route, options=options, apikey=apikey, apiroot=apiroot, verbose=verbose)
+            q = argofetch(route, options=copy.deepcopy(options), apikey=apikey, apiroot=apiroot, verbose=verbose)
             return q[0]
         except Exception as e:
             if e.args[0] == 413:
                 # we need to slice
-                return query(route=route, options=options, apikey=apikey, apiroot=apiroot, verbose=verbose, slice=True)
+                return query(route=route, options=copy.deepcopy(options), apikey=apikey, apiroot=apiroot, verbose=verbose, slice=True)
             else:
                 print(e)
                 return e.args

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -192,5 +192,21 @@ def test_dont_wrap_dateline(apiroot, apikey):
     assert helpers.dont_wrap_dateline([[-175,0],[175,0],[175,10],[-175,10],[-175,0]]) == [[185,0],[175,0],[175,10],[185,10],[185,0]], 'unwrap cw'
     assert helpers.dont_wrap_dateline([[5,0],[-5,0],[-5,5],[5,5],[5,0]]) == [[5,0],[-5,0],[-5,5],[5,5],[5,0]], 'unwrap shoudnt affect meridian crossing'
 
+def test_big_time_slice(apiroot, apikey):
+    '''
+    check that slicing in a query with a long time range and polygon is working correctly
+    '''
 
+    natlantic = [[-52.91015625000001,57.57635026510582],[-47.4609375,58.59841337380398],[-41.13281250000001,58.96285043960036],[-36.12304687500001,58.73552560169896],[-28.828125000000004,58.781109991263875],[-24.433593750000004,58.91750479454867],[-17.929687500000004,58.82663462015099],[-12.216796875000002,58.50670551226914],[-12.392578125,41.263494202188674],[-20.126953125000004,41.06499545917395],[-28.388671875000004,41.592988409051024],[-37.44140625000001,40.865895731685946],[-45.87890625,41.78988186577712],[-52.11914062500001,41.724317678639935],[-52.91015625000001,57.57635026510582]]
+    options = {
+        'startDate': '2000-01-01T00:00:00Z',
+        'endDate': '2021-01-01T00:00:00Z',
+        'polygon': natlantic,
+        'presRange': '0,100',
+        'compression': 'minimal',
+        'data': 'doxy,1'
+    }
+    response = helpers.query('/argo', options=options, apikey='regular', apiroot=apiroot)
+    print(response)
+    assert len(response) == 0, 'query should run to completion with no result'
 


### PR DESCRIPTION
If a query had a polygon region and fails to fetch in one go, the polygon region ended up getting cast to a string incorrectly on subsequent tries.